### PR TITLE
use feature(new_uninit)

### DIFF
--- a/src/static_aabb2d_index.rs
+++ b/src/static_aabb2d_index.rs
@@ -215,9 +215,7 @@ where
             .collect();
 
         #[cfg(feature = "unsafe_optimizations")]
-        let boxes = std::iter::repeat_with(std::mem::MaybeUninit::uninit)
-            .take(num_nodes)
-            .collect();
+        let boxes = Box::new_uninit_slice(num_nodes);
 
         StaticAABB2DIndexBuilder {
             node_size,


### PR DESCRIPTION
Use Rust feature `new_uninit`, stabilised since 1.82.